### PR TITLE
Key bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Returns a private key for use by the recipient, given the sender's public key, t
     *   `obj.recipientPrivateKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The private key of the recipient in WIF format
     *   `obj.senderPublicKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The public key of the sender in hexadecimal DER format
     *   `obj.invoiceNumber` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The invoice number that was used
-    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, `wif`, `hex`, `buffer`, or `bsv` (optional, default `wif`) - Note: specifying a return type of 'bsv' will require you to use an argument of { size: 32 } when calling .toHex() or .toBuffer() on the bsv object.
+    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, `wif`, `hex`, `buffer`, or `bsv` (optional, default `wif`) - Note: specifying a return type of `bsv` will require you to use an argument of `{ size: 32 }` when calling `.toHex()` or `.toBuffer()` on the bsv object.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** | **[Buffer](https://nodejs.org/api/buffer.html)** | **[BN](https://github.com/moneybutton/bsv/blob/bsv-legacy/lib/crypto/bn.js)** The incoming payment key that can unlock the money.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Returns a private key for use by the recipient, given the sender's public key, t
     *   `obj.recipientPrivateKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The private key of the recipient in WIF format
     *   `obj.senderPublicKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The public key of the sender in hexadecimal DER format
     *   `obj.invoiceNumber` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The invoice number that was used
-    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, `wif`, `hex`, `buffer`, or `bsv` (optional, default `wif`) - Note: specifying a return type of `bsv` will require you to use an argument of `{ size: 32 }` when calling `.toHex()` or `.toBuffer()` on the bsv object.
+    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, `wif`, `hex`, `buffer`, or `bsv` (optional, default `wif`) - Note: specifying a return type of `bsv` will require you to use an argument of `{ size: 32 }` when calling `.toHex()` or `.toBuffer()` on the BN object.
 
 Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** | **[Buffer](https://nodejs.org/api/buffer.html)** | **[BN](https://github.com/moneybutton/bsv/blob/bsv-legacy/lib/crypto/bn.js)** The incoming payment key that can unlock the money.
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ Returns a private key for use by the recipient, given the sender's public key, t
     *   `obj.recipientPrivateKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The private key of the recipient in WIF format
     *   `obj.senderPublicKey` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The public key of the sender in hexadecimal DER format
     *   `obj.invoiceNumber` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The invoice number that was used
-    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, either `wif` or `hex` (optional, default `wif`)
+    *   `obj.returnType` **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key return type, `wif`, `hex`, `buffer`, or `bsv` (optional, default `wif`) - Note: specifying a return type of 'bsv' will require you to use an argument of { size: 32 } when calling .toHex() or .toBuffer() on the bsv object.
 
-Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** The incoming payment key that can unlock the money.
+Returns **[String](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/String)** | **[Buffer](https://nodejs.org/api/buffer.html)** | **[BN](https://github.com/moneybutton/bsv/blob/bsv-legacy/lib/crypto/bn.js)** The incoming payment key that can unlock the money.
 
 ## Credits
 

--- a/src/__tests/getPaymentAddress.test.js
+++ b/src/__tests/getPaymentAddress.test.js
@@ -43,12 +43,12 @@ describe('getPaymentAddress', () => {
       .randomBytes(8)
       .toString('base64')
     expect(() => {
-     getPaymentAddress({
-      senderPrivateKey: senderKeypair.privateKey,
-      recipientPublicKey: recipientKeypair.publicKey,
-      invoiceNumber: testInvoiceNumber,
-      returnType: 'privateKey'
-    })
+      getPaymentAddress({
+        senderPrivateKey: senderKeypair.privateKey,
+        recipientPublicKey: recipientKeypair.publicKey,
+        invoiceNumber: testInvoiceNumber,
+        returnType: 'privateKey'
+      })
     }).toThrow(new Error(
       'The return type must either be "address" or "publicKey"'
     ))

--- a/src/__tests/getPaymentPrivateKey.test.js
+++ b/src/__tests/getPaymentPrivateKey.test.js
@@ -2,7 +2,8 @@
 const getPaymentPrivateKey = require('../getPaymentPrivateKey')
 const generateKeypair = require('../generateKeypair')
 const bsv = require('bsv')
-const testVectors = require('./getPaymentPrivateKey.vectors')
+// const testVectors = require('./getPaymentPrivateKey.vectors')
+const { generateTestVectors } = require('./getPaymentPrivateKey.vectorGenerator')
 
 describe('getPaymentPrivateKey', () => {
   it('Returns a valid Bitcoin SV private key', () => {
@@ -110,13 +111,17 @@ describe('getPaymentPrivateKey', () => {
     })
     expect(firstResult).not.toEqual(secondResult)
   })
+  const testVectors = generateTestVectors()
   testVectors.forEach((vector, index) => {
     it(`Passes test vector #${index + 1}`, () => {
-      expect(getPaymentPrivateKey({
+      const privateKey = getPaymentPrivateKey({
         senderPublicKey: vector.senderPublicKey,
         recipientPrivateKey: vector.recipientPrivateKey,
-        invoiceNumber: vector.invoiceNumber
-      })).toEqual(vector.privateKey)
+        invoiceNumber: vector.invoiceNumber,
+        returnType: 'hex'
+      })
+      expect(privateKey.length).toEqual(64)
+      expect(privateKey).toEqual(vector.privateKey)
     })
   })
 })

--- a/src/__tests/getPaymentPrivateKey.test.js
+++ b/src/__tests/getPaymentPrivateKey.test.js
@@ -36,6 +36,22 @@ describe('getPaymentPrivateKey', () => {
       bsv.PrivateKey.fromHex(result)
     }).not.toThrow()
   })
+  it('Returns a valid buffer array', () => {
+    const senderKeypair = generateKeypair()
+    const recipientKeypair = generateKeypair()
+    const testInvoiceNumber = require('crypto')
+      .randomBytes(8)
+      .toString('base64')
+    const result = getPaymentPrivateKey({
+      senderPublicKey: senderKeypair.publicKey,
+      recipientPrivateKey: recipientKeypair.privateKey,
+      invoiceNumber: testInvoiceNumber,
+      returnType: 'buffer'
+    })
+    expect(() => {
+      bsv.PrivateKey.fromBuffer(result)
+    }).not.toThrow()
+  })
   it('Throws an error if an invalid return type is given', () => {
     const senderKeypair = generateKeypair()
     const recipientKeypair = generateKeypair()
@@ -52,6 +68,26 @@ describe('getPaymentPrivateKey', () => {
     }).toThrow(new Error(
       'The return type must either be "wif" or "hex"'
     ))
+  })
+  it('Pads private keys with zeros if their size is less than 32 bytes', () => {
+    // Generates a private key that meets the criteria described above
+    const result = getPaymentPrivateKey({
+      senderPublicKey: '040c2cb7c02421257c7cc01e95288e0167bb4982f6ed7f06843ca908a7ee987bcc5e79df21aee01631cca74ba10b92c3053016514c79434f49e952304717df9f87',
+      recipientPrivateKey: 'a4f4ad15349c25ed3d8bf69a713a2c3099f76adeb11cf3d1c5d9abb15e00f4a0',
+      invoiceNumber: 1,
+      returnType: 'hex'
+    })
+    expect(result.length).toEqual(64)
+  })
+  it('Returns a bsv BN object that can be used to retrieve a 32 byte hex string', () => {
+    // Generates a private key that meets the criteria described above
+    const result = getPaymentPrivateKey({
+      senderPublicKey: '040c2cb7c02421257c7cc01e95288e0167bb4982f6ed7f06843ca908a7ee987bcc5e79df21aee01631cca74ba10b92c3053016514c79434f49e952304717df9f87',
+      recipientPrivateKey: 'a4f4ad15349c25ed3d8bf69a713a2c3099f76adeb11cf3d1c5d9abb15e00f4a0',
+      invoiceNumber: 1,
+      returnType: 'bsv'
+    })
+    expect(result.toHex({ size: 32 }).length).toEqual(64)
   })
   it('Returns a different private key with a different invoice number', () => {
     const senderKeypair = generateKeypair()

--- a/src/__tests/getPaymentPrivateKey.vectorGenerator.js
+++ b/src/__tests/getPaymentPrivateKey.vectorGenerator.js
@@ -1,24 +1,27 @@
 const getPaymentPrivateKey = require('../getPaymentPrivateKey')
 const generateKeypair = require('../generateKeypair')
 
-const vectors = []
-for (let i = 0; i < 5; i++) {
-  const senderKeypair = generateKeypair()
-  const recipientKeypair = generateKeypair()
-  const invoiceNumber = require('crypto')
-    .randomBytes(8)
-    .toString('base64')
-  const result = getPaymentPrivateKey({
-    senderPublicKey: senderKeypair.publicKey,
-    recipientPrivateKey: recipientKeypair.privateKey,
-    invoiceNumber: invoiceNumber
-  })
-  vectors.push({
-    senderPublicKey: senderKeypair.publicKey,
-    recipientPrivateKey: recipientKeypair.privateKey,
-    invoiceNumber: invoiceNumber,
-    privateKey: result
-  })
+const generateTestVectors = () => {
+  const vectors = []
+  for (let i = 0; i < 500; i++) {
+    const senderKeypair = generateKeypair()
+    const recipientKeypair = generateKeypair()
+    const invoiceNumber = require('crypto')
+      .randomBytes(8)
+      .toString('base64')
+    const result = getPaymentPrivateKey({
+      senderPublicKey: senderKeypair.publicKey,
+      recipientPrivateKey: recipientKeypair.privateKey,
+      invoiceNumber: invoiceNumber,
+      returnType: 'hex'
+    })
+    vectors.push({
+      senderPublicKey: senderKeypair.publicKey,
+      recipientPrivateKey: recipientKeypair.privateKey,
+      invoiceNumber: invoiceNumber,
+      privateKey: result
+    })
+  }
+  return vectors
 }
-
-console.log(JSON.stringify(vectors, null, 2))
+module.exports = { generateTestVectors }

--- a/src/generateKeypair.js
+++ b/src/generateKeypair.js
@@ -17,7 +17,7 @@ module.exports = ({ returnType = 'hex' } = {}) => {
     }
   } else {
     return {
-      privateKey: privateKey.bn.toHex(),
+      privateKey: privateKey.bn.toHex({ size: 32 }),
       publicKey: privateKey.publicKey.toString()
     }
   }

--- a/src/getPaymentPrivateKey.js
+++ b/src/getPaymentPrivateKey.js
@@ -49,17 +49,16 @@ module.exports = ({
   // Finally, the hmac is added to the private key, and the result is modulo N.
   const finalPrivateKey = privateKey.add(BN.fromBuffer(hmac)).mod(N)
 
-  if (returnType === 'wif') {
-    return new bsv.PrivateKey(finalPrivateKey).toWIF()
-  } else if (returnType === 'hex') {
-    let privateKeyInHex = finalPrivateKey.toHex()
-    while (privateKeyInHex.length !== 64) {
-      privateKeyInHex = '0' + privateKeyInHex
-    }
-    return privateKeyInHex
-  } else if (returnType === 'bsv') {
-    return finalPrivateKey
-  } else {
-    throw new Error('The return type must either be "wif" or "hex"')
+  switch (returnType) {
+    case 'wif':
+      return new bsv.PrivateKey(finalPrivateKey).toWIF()
+    case 'hex':
+      return finalPrivateKey.toHex({ size: 32 })
+    case 'buffer':
+      return finalPrivateKey.toBuffer({ size: 32 })
+    case 'bsv':
+      return finalPrivateKey
+    default:
+      throw new Error('The return type must either be "wif" or "hex"')
   }
 }


### PR DESCRIPTION
- Added a simpler way for returning a private key as hex
- Added support for returnType of a buffer
- Added tests for outlier key sizes less than 32 bytes
- Updated the README